### PR TITLE
DNM travis: build using composer-merge

### DIFF
--- a/build/travis/composer.local.json
+++ b/build/travis/composer.local.json
@@ -1,0 +1,10 @@
+{
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/Wikibase/composer.json",
+				"extensions/Scribunto/composer.json"
+			]
+		}
+	}
+}

--- a/build/travis/install.sh
+++ b/build/travis/install.sh
@@ -18,7 +18,19 @@ wget https://github.com/wikimedia/mediawiki/archive/$MW.tar.gz
 tar -zxf $MW.tar.gz
 mv mediawiki-$MW phase3
 
-cd phase3
+cd phase3/extensions
+
+if [ "$WB" != "repo" ]; then
+	git clone https://gerrit.wikimedia.org/r/p/mediawiki/extensions/Scribunto.git --depth 1
+fi
+git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/cldr --depth 1
+
+cp -r $originalDirectory Wikibase
+
+cd ..
+
+cp $originalDirectory/build/travis/composer.local.json composer.local.json
+
 composer self-update
 composer install
 
@@ -29,21 +41,3 @@ fi
 
 mysql -e 'create database its_a_mw;'
 php maintenance/install.php --dbtype $DBTYPE --dbuser root --dbname its_a_mw --dbpath $(pwd) --pass nyan TravisWiki admin
-
-cd extensions
-
-if [ "$WB" != "repo" ]; then
-	git clone https://gerrit.wikimedia.org/r/p/mediawiki/extensions/Scribunto.git --depth 1
-fi
-git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/cldr --depth 1
-
-cp -r $originalDirectory Wikibase
-
-cd Wikibase
-
-composer install --prefer-source
-
-# Try composer install again... this tends to fail from time to time
-if [ $? -gt 0 ]; then
-	composer install --prefer-source
-fi

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -5,7 +5,3 @@ set -ex
 cd ../phase3/tests/phpunit
 
 php phpunit.php --group Wikibase,Purtle
-
-cd ../../extensions/Wikibase
-
-composer test


### PR DESCRIPTION
This is to trigger a travis build. gerrit is at https://gerrit.wikimedia.org/r/#/c/mediawiki/extensions/Wikibase/+/450216/

I9d535473ea30dcd15b3e60244673d770177e608f made the use of the composer
merge plugin mandatory.

Bug: T201161