### PR TITLE
travis: build release branches with respective MW branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ matrix:
     - env: DBTYPE=sqlite LANG=ru WB=both
       php: 7.3
     - env: DBTYPE=sqlite LANG=en WB=client
-      php: 7.2
+      php: 7.3
     - env: DBTYPE=mysql LANG=en WB=repo
-      php: 7.2
+      php: 7.3
     - env: DBTYPE=sqlite LANG=ar WB=both
       php: 7.3
-    - env: DBTYPE=mysql LANG=en WB=both
-      php: 7.2
     - env: DBTYPE=mysql LANG=en WB=both
       php: 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: DBTYPE=sqlite LANG=ru MW=master WB=both
+    - env: DBTYPE=sqlite LANG=ru WB=both
       php: 7.3
-    - env: DBTYPE=sqlite LANG=en MW=master WB=client
+    - env: DBTYPE=sqlite LANG=en WB=client
       php: 7.2
-    - env: DBTYPE=mysql LANG=en MW=master WB=repo
+    - env: DBTYPE=mysql LANG=en WB=repo
       php: 7.2
-    - env: DBTYPE=sqlite LANG=ar MW=master WB=both
+    - env: DBTYPE=sqlite LANG=ar WB=both
       php: 7.3
-    - env: DBTYPE=mysql LANG=en MW=master WB=both
+    - env: DBTYPE=mysql LANG=en WB=both
       php: 7.2
-    - env: DBTYPE=mysql LANG=en MW=master WB=both
+    - env: DBTYPE=mysql LANG=en WB=both
       php: 7.3
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ matrix:
   fast_finish: true
   include:
     - env: DBTYPE=sqlite LANG=ru WB=both
-      php: 7.3
+      php: 7.3.19
     - env: DBTYPE=sqlite LANG=en WB=client
-      php: 7.3
+      php: 7.3.19
     - env: DBTYPE=mysql LANG=en WB=repo
-      php: 7.3
+      php: 7.3.19
     - env: DBTYPE=sqlite LANG=ar WB=both
-      php: 7.3
+      php: 7.3.19
     - env: DBTYPE=mysql LANG=en WB=both
-      php: 7.3
+      php: 7.3.19
 
 before_script:
     - bash ./build/travis/install.sh

--- a/build/travis/install.sh
+++ b/build/travis/install.sh
@@ -8,9 +8,13 @@ originalDirectory=$(pwd)
 
 cd ..
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW.tar.gz
-tar -zxf $MW.tar.gz
-mv mediawiki-$MW phase3
+MW_BRANCH=master
+if [[ "$TRAVIS_BRANCH" =~ ^wmf/[0-9]+.* ]] || [[ "$TRAVIS_BRANCH" =~ ^REL[0-9]+_[0-9]+ ]]; then
+	MW_BRANCH="$TRAVIS_BRANCH"
+fi
+
+mkdir phase3
+wget -O- https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz | tar -zxf - -C phase3 --strip-components 1
 
 cd phase3/extensions
 


### PR DESCRIPTION
Branch names can contain slashes, which are not fit for use as folder
names - replacing the existing untar solution to avoid having to
know/generate file+folder name by string processing MW_BRANCH. Fingers
crossed that --strip-components is available on travis.

Bug: T263994
Change-Id: I3f61effd4af80253208f28151ebf4b79922c9709

---

Cherry-picked from [change I3f61effd4a](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/630626) – let’s see if Travis likes it.